### PR TITLE
Move to file-based redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,76 @@
 ![banner](./.github/banner.png)
 
-a simple redirector engine for cloudflare workers.
+A simple (but powerful!) redirect tool built with Cloudflare Workers. Deploy and manage redirects at the edge without needing to config your origin application.
 
 ![demo](./.github/demo.png)
 
-## installation
+## Installation
 
-1. install the package
+This project requires the usage of Cloudflare Workers on your custom domain/zone. Check out my Egghead video on [deploying to a custom domain](https://next.egghead.io/lessons/cloudflare-deploy-to-a-custom-domain-with-cloudflare-wrangler-environments) if you need to set that up.
+
+With a configured Workers project, using Wrangler:
+
+1. Install the package
 
 ```bash
 $ npm install lilredirector
 ```
 
-2. create a kv namespace called `REDIRECTS` using wrangler
+2. Create a `redirects.js` file in your source code:
 
-```bash
-$ wrangler kv:namespace create REDIRECTS
+```javascript
+export default [
+  {
+    path: "/twitter",
+    redirect: "https://twitter.com/signalnerve",
+  },
+  {
+    path: "/yt",
+    redirect: "https://www.youtube.com/c/bytesizedxyz",
+  },
+]
 ```
 
-3. add the `kv-namespace` provided by wrangler output to `wrangler.toml`
-
-```toml
-kv_namespaces = [{ binding = "REDIRECTS", id = "$id", preview_id = "$id" }]
-```
-
-## usage
+## Usage
 
 ```javascript
 import redirector from 'lilredirector'
+import redirects from './redirects'
 
 addEventListener('fetch', event => event.respondWith(handler(event)))
 
-// note the `event` function argument! many workers scripts will
-// pass in `event.request`, lilredirector needs the full `event` object
+// Note the `event` function argument. 
+// Unlike many Workers scripts, which pass in `event.request`, 
+// lilredirector needs the full `event` object
 async function handler(event) {
-  const { response, error } = await redirector(event)
+  const { response, error } = await redirector(event, redirects)
   if (response) return response
 
-  // optionally return an error response
+  // Optionally, return an error response
   if (error) return error
 
-  // other workers code
+  // Other workers code
 }
 ```
 
-## configuration
+### Path parameters
+
+Lilredirector includes support for more complex redirect scenarios using _path parameters_. This allows you to capture parameters in the URL and use it to route to new URLs. In `redirects.js`:
+
+```javascript
+export default [
+  {
+    path: "/post/:id",
+    redirect: "/posts/:id"
+  },
+  {
+    path: "/users/:id/posts/:post_id",
+    redirect: "/u/:id/p/:post_id"
+  },
+]
+```
+
+## Configuration
 
 ```javascript
 import redirector from 'lilredirector'
@@ -52,112 +78,61 @@ import redirector from 'lilredirector'
 addEventListener('fetch', event => event.respondWith(handler(event)))
 
 async function handler(event) {
-  const { response, error } = await redirector(event, {
-    // configuration options can be passed as an optional object.
-    // see the below documentation for examples of each:
+  const { response, error } = await redirector(event, redirects, {
+    // Configuration options can be passed as an optional object.
+    // See the below documentation for examples of each:
     //
     // baseUrl
     // basicAuthentication
-    // cancelBulkAddOnError
     // removeTrailingSlashes
-    // validateRedirects
   })
   // ...
 }
 ```
 
-### changing the base url
+### Changing the base URL
 
-by default, lilredirector serves the UI and any associated data handlers from `/_redirects`. this can be customized by providing `baseUrl` in lilredirector's configuration:
+By default, lilredirector serves a read-only UI from `/_redirects`. This can be customized by providing `baseUrl` in lilredirector's configuration:
 
 ```javascript
 async function handler(event) {
-  const { response, error } = await redirector(event, {
+  const { response, error } = await redirector(event, redirects,{
     baseUrl: `/mylilredirector`,
   })
   if (response) return response
 }
 ```
 
-### removing trailing slashes
+### Removing trailing slashes
 
-by default, lilredirector will match and redirect URLs _without_ trailing slashes. for instance, if you have a redirect set up for `/about`, visiting `/about/` will search for a redirect for `/about` in the lilredirector database, and redirect accordingly. this feature can be disabled by passing the `removeTrailingSlashes` boolean in the configuration object into the `redirector` function:
+By default, lilredirector will match and redirect URLs _without_ trailing slashes. For instance, if you have a redirect set up for `/about`, visiting `/about/` will match a redirect for `/about`, and redirect accordingly. This feature can be disabled by passing the `removeTrailingSlashes` boolean in the configuration object into the `redirector` function:
 
 ```javascript
 async function handler(event) {
-  const { response, error } = await redirector(event, {
+  const { response, error } = await redirector(event, redirects, {
     removeTrailingSlashes: false,
   })
   if (response) return response
 }
 ```
 
-### validating redirects
+## How it works
 
-by default, lilredirector will validate a redirect before allowing it to be saved. for instance, if you attempt to save a redirect for `/about` that points to `/foo`, a page that doesn't exist, lilredirector will error on save and return an error message in the UI. this can be disabled using the config option `validateRedirects`
+#### Handlers
 
-```javascript
-async function handler(event) {
-  const { response, error } = await redirector(event, {
-    validateRedirects: false,
-  })
-  if (response) return response
-}
-```
+Lilredirector embeds itself under the `/_redirects` path, unless specified otherwise by the `baseUrl` configuration param as defined in the previous section. 
 
-### canceling bulk adds on validation errors
+## Authentication
 
-as of lilredirector 0.2.0, there is support in the UI for adding multiple redirects using a bulk UI. if the above `validateRedirects` option is enabled, lilredirector will validate each redirect inside of the bulk operation before saving.
+You can put the read-only UI behind authentication using a few methods.
 
-by default, lilredirector will save valid URLs in a bulk operation even if some are invalid - instead of canceling the operation completely, it will return an error message indicating the individual failed/invalid URLs.
+### Basic authentication
 
-this can be changed using the `cancelBulkAddOnError` value in configuration, which will cause the entire bulk operation to cancel if any of the URLs are found to be invalid:
-
-```javascript
-async function handler(event) {
-  const { response, error } = await redirector(event, {
-    cancelBulkAddOnError: true,
-  })
-  if (response) return response
-}
-```
-
-## how it works
-
-#### handlers
-
-lilredirector embeds itself under the `/_redirects` path, unless specified otherwise by the `baseUrl` configuration param as defined in the previous section. here's a list of the paths you'll be adding to your application:
-
-| path                 | fn                             |
-| -------------------- | ------------------------------ |
-| `/_redirects`        | ui                             |
-| `/_redirects/delete` | redirect delete handler        |
-| `/_redirects/update` | redirect create/update handler |
-
-#### editor
-
-manage and create new redirects at `/_redirects`!
-
-as of version 0.2.0, the lilredirector UI has support for _bulk redirect adding_. using the "add multiple redirects" dropdown, you can add redirects in a larger `textarea` element using CSV format, as seen below:
-
-```csv
-/firsturl,https://myredirectlocation.com
-/second,https://mysecondredirectlocation.com
-```
-
-_this feature is beta and may be prone to errors._ simple comma-separated value CSVs with no headers/footers are the only tested and supported values for this field at this time.
-
-## authentication
-
-you should really, really put this behind authentication!
-
-### basic authentication
-
-using the configuration object, you can enable basic auth for lilredirector and any subpaths (creating/deleting redirects):
+Using the configuration object, you can enable basic auth for lilredirector and any subpaths (creating/deleting redirects):
 
 ```js
 async function handler(event) {
-  const { response, error } = await redirector(event, {
+  const { response, error } = await redirector(event, redirects, {
     basicAuthentication: {
       username: USERNAME,
       password: PASSWORD,
@@ -167,15 +142,15 @@ async function handler(event) {
 }
 ```
 
-it is strongly recommended that you use `wrangler secret` to define and store your basic auth credentials, as seen above:
+It's strongly recommended that you use `wrangler secret` to define and store your basic auth credentials, as seen above:
 
 ```bash
 $ wrangler secret put USERNAME
 $ wrangler secret put PASSWORD
 ```
 
-### cloudflare access
+### Cloudflare Access
 
-you can add complex role-based auth using [cloudflare access](https://teams.cloudflare.com/access/). see the below screenshot for an example config:
+You can add complex role-based auth using [cloudflare access](https://teams.cloudflare.com/access/). see the below screenshot for an example config:
 
 ![access setup](./.github/access-preview.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,96 @@
 {
   "name": "lilredirector",
-  "version": "0.5.1",
-  "lockfileVersion": 1,
+  "version": "0.9.9",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.9.9",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/workers-types": "^2.0.0",
+        "@types/basic-auth": "^1.1.3",
+        "basic-auth": "^2.0.1",
+        "tiny-request-router": "^1.2.2"
+      },
+      "devDependencies": {
+        "prettier": "^1.19.1",
+        "typescript": "^4.0.2"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.0.0.tgz",
+      "integrity": "sha512-SFUPQzR5aV2TBLP4Re+xNX5KfAGArcRGA44OLulBDnfblEf3J+6kFvdJAQwFhFpqru3wImwT1cX0wahk6EeWTw=="
+    },
+    "node_modules/@types/basic-auth": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.3.tgz",
+      "integrity": "sha512-W3rv6J0IGlxqgE2eQ2pTb0gBjaGtejQpJ6uaCjz3UQ65+TFTPC5/lAE+POfx1YLdjtxvejJzsIAfd3MxWiVmfg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+    },
+    "node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/tiny-request-router": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tiny-request-router/-/tiny-request-router-1.2.2.tgz",
+      "integrity": "sha512-6ZMFU7AP9so+hkqmMM9fJ11V44EAcYuHCmNdsyM8k94oVnNDPQwUAAPoBHqchHSpKG6yZbCasgVeRxaY5v2BCg==",
+      "dependencies": {
+        "path-to-regexp": "^6.1.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@cloudflare/workers-types": {
       "version": "2.0.0",
@@ -22,14 +110,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
       "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
     },
-    "@types/papaparse": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.0.6.tgz",
-      "integrity": "sha512-fCQnycsOSviVLtxuydQ82IhTAv1lSPIA8zY3sYaRHI00lERsa7QSA616HsQZixqEF2asGXZag3hM13N8bm/jAw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -38,10 +118,10 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "papaparse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz",
-      "integrity": "sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA=="
+    "path-to-regexp": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "prettier": {
       "version": "1.19.1",
@@ -53,6 +133,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "tiny-request-router": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tiny-request-router/-/tiny-request-router-1.2.2.tgz",
+      "integrity": "sha512-6ZMFU7AP9so+hkqmMM9fJ11V44EAcYuHCmNdsyM8k94oVnNDPQwUAAPoBHqchHSpKG6yZbCasgVeRxaY5v2BCg==",
+      "requires": {
+        "path-to-regexp": "^6.1.0"
+      }
     },
     "typescript": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilredirector",
-  "version": "0.5.1",
+  "version": "0.9.9",
   "description": "redirector engine for cloudflare workers",
   "main": "dist/index.js",
   "scripts": {
@@ -18,8 +18,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^2.0.0",
     "@types/basic-auth": "^1.1.3",
-    "@types/papaparse": "^5.0.6",
     "basic-auth": "^2.0.1",
-    "papaparse": "^5.2.0"
+    "tiny-request-router": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilredirector",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "redirector engine for cloudflare workers",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,103 +1,8 @@
 import auth from 'basic-auth'
-import CSV from 'papaparse'
+import Router from './router'
 import template from './template'
 
-declare global {
-  const REDIRECTS: KVNamespace
-}
-
-import type { CSVData } from './types'
-
-const gatherRedirects = async () => {
-  let keys: string[] = []
-  let listOpts = { prefix: 'redirects:' }
-  let { cursor, keys: kvKeys, list_complete } = await REDIRECTS.list(listOpts)
-  keys = keys.concat(kvKeys.map(k => k.name))
-
-  while (!list_complete) {
-    let kvReq = await REDIRECTS.list(
-      Object.assign(listOpts, { cursor: cursor }),
-    )
-    keys = keys.concat(kvReq.keys.map(k => k.name))
-    cursor = kvReq.cursor
-    list_complete = kvReq.list_complete
-  }
-
-  const redirects = await Promise.all(
-    keys.map(async k => {
-      const data = await REDIRECTS.get(k)
-      if (!data) return {}
-      return JSON.parse(data)
-    }),
-  )
-  return redirects
-}
-
-const updateRedirect = async ({
-  path: unsanitizedPath,
-  redirect: unsanitizedRedirect,
-}: {
-  path: string
-  redirect: string
-}) => {
-  const path = unsanitizedPath.trim()
-  const redirect = unsanitizedRedirect.trim()
-  try {
-    await REDIRECTS.put(
-      `redirects:${path}`,
-      JSON.stringify({
-        path,
-        redirect,
-        visits: 0,
-      }),
-    )
-    return true
-  } catch (err) {
-    console.error(err)
-    return false
-  }
-}
-
-const deleteRedirect = async ({ path }: { path: string }) => {
-  await REDIRECTS.delete(`redirects:${path}`)
-  return true
-}
-
-const redirectToUrl = (redirect: string, url: URL): URL => {
-  console.log(redirect)
-  if (redirect.startsWith('/')) {
-    let newUrl = new URL(url.toString())
-    newUrl.pathname = redirect
-    return newUrl
-  } else {
-    return new URL(redirect)
-  }
-}
-
-const getRedirect = async (
-  url: URL,
-  { event }: { event: FetchEvent },
-): Promise<URL | null> => {
-  const key = `redirects:${url.pathname}`
-  const kvData = await REDIRECTS.get(key)
-  if (!kvData) return null
-  const result = JSON.parse(kvData)
-  if (result) {
-    event.waitUntil(
-      REDIRECTS.put(
-        key,
-        JSON.stringify(
-          Object.assign(result, {
-            visits: result.visits + 1,
-          }),
-        ),
-      ),
-    )
-    const redirect = result.redirect
-    return redirectToUrl(redirect, url)
-  }
-  return null
-}
+import type { Redirect } from './types'
 
 const renderHtml = (page: () => string) =>
   new Response(page(), {
@@ -114,17 +19,17 @@ const defaults = {
     password: null,
   },
   baseUrl: '/_redirects',
-  cancelBulkAddOnError: false,
   removeTrailingSlashes: true,
-  validateRedirects: true,
 }
 
-export default async (event: FetchEvent, options = {}) => {
+export default async (event: FetchEvent, redirects: Array<Redirect>, options = {}) => {
   const { request } = event
   const config = Object.assign(defaults, options)
   const { basicAuthentication, baseUrl } = config
   let error, response
   let url = new URL(event.request.url)
+
+  const router = Router(redirects)
 
   if (url.pathname.startsWith(config.baseUrl)) {
     if (basicAuthentication.username && basicAuthentication.password) {
@@ -154,111 +59,12 @@ export default async (event: FetchEvent, options = {}) => {
   try {
     switch (url.pathname) {
       case `${baseUrl}`:
-        const redirects = await gatherRedirects()
         response = renderHtml(template({ baseUrl, redirects }))
-        break
-      case `${baseUrl}/delete`:
-        const pathParam = url.searchParams.get('path')
-        if (!pathParam) {
-          response = new Response(null, { status: 500 })
-          break
-        }
-        await deleteRedirect({
-          path: pathParam,
-        })
-        response = new Response(null, { status: 204 })
-        break
-      case `${baseUrl}/update`:
-        let updateError = false
-        const formData = await request.formData()
-        const body: { [key: string]: string } = {}
-        for (const entry of formData.entries()) {
-          const [key, value] = entry
-          if (key && value) {
-            body[key] = value.toString()
-          }
-        }
-        const { bulk, path, redirect } = body
-        let redirectObjs = []
-        if (bulk) {
-          let errors: string[] = []
-          const { data }: { data: CSVData } = CSV.parse(bulk)
-          await Promise.all(
-            data.map(async ([path, redirect]) => {
-              if (!path || !redirect) return
-              if (config.validateRedirects) {
-                const fetchUrl = redirectToUrl(redirect, url)
-                const resp = await fetch(fetchUrl.toString())
-                if (resp.status > 399) {
-                  if (config.cancelBulkAddOnError) updateError = true
-                  errors.push(
-                    `Invalid URL provided or request to URL failed, unable to save: ${redirect}`,
-                  )
-                  return
-                }
-              }
-
-              if (config.removeTrailingSlashes && path.endsWith('/')) {
-                path = path.slice(0, -1)
-              }
-
-              if (config.removeTrailingSlashes && redirect.endsWith('/')) {
-                redirect = redirect.slice(0, -1)
-              }
-
-              redirectObjs.push({
-                path,
-                redirect,
-              })
-            }),
-          )
-
-          if (errors.length) {
-            url.searchParams.set('error', errors.join('<br>'))
-          }
-        } else {
-          if (config.validateRedirects) {
-            const resp = await fetch(redirectToUrl(redirect, url).toString())
-            if (resp.status > 299) {
-              updateError = true
-              url.searchParams.set(
-                'error',
-                `Invalid URL provided or request to URL, unable to save: ${redirect}`,
-              )
-            }
-          }
-
-          if (!updateError) {
-            redirectObjs.push({
-              path,
-              redirect,
-            })
-          }
-        }
-
-        url.searchParams.delete('bulk')
-        url.searchParams.delete('path')
-        url.searchParams.delete('redirect')
-
-        if (!updateError) {
-          const updated = await Promise.all(redirectObjs.map(updateRedirect))
-          if (updated.some(u => u === false)) {
-            url.searchParams.set(
-              'error',
-              'Something went wrong while saving your redirects',
-            )
-          }
-        }
-
-        url.pathname = baseUrl
-        response = Response.redirect(url.toString())
         break
       default:
         if (config.removeTrailingSlashes) removeTrailingSlashesFromUrl(url)
-        const foundRedirect = await getRedirect(url, { event })
-        if (foundRedirect) {
-          response = Response.redirect(foundRedirect.toString())
-        }
+        const match = router.match('GET', url.pathname)
+        if (match) response = match.handler(match.params)
         break
     }
   } catch (err) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,21 @@
+import { Router } from 'tiny-request-router'
+import type { Params } from 'tiny-request-router'
+import type { Redirect } from './types'
+
+type Handler = (params: Params) => Promise<Response>
+
+const Routes = (redirects: Array<Redirect>): Router<Handler> => {
+  const router = new Router<Handler>()
+  redirects.forEach(redirect => {
+    router.get(redirect.path, async (params: Params) => {
+      let redirectPath = redirect.redirect
+      Object.keys(params).forEach(key =>
+        redirectPath = redirectPath.replace(`:${key}`, params[key])
+      )
+      return Response.redirect(redirectPath)
+    })
+  })
+  return router
+}
+
+export default Routes

--- a/src/template.ts
+++ b/src/template.ts
@@ -17,32 +17,6 @@ export default ({
         background-color: #f9fafb;
         background-color: rgba(249,250,251,1);
       }
-
-      .form-input {
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
-        background-color: #fff;
-        border-color: #d2d6dc;
-        border-width: 1px;
-        border-radius: .375rem;
-        padding: .5rem .75rem;
-        font-size: 1rem;
-        line-height: 1.5;
-      }
-
-      .form-textarea {
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
-        background-color: #fff;
-        border-color: #d2d6dc;
-        border-width: 1px;
-        border-radius: .375rem;
-        padding: .5rem .75rem;
-        font-size: 1rem;
-        line-height: 1.5;
-      }
     </style>
   </head>
   <body>
@@ -51,7 +25,7 @@ export default ({
         <img class="w-16 h-16 mr-2" src="https://raw.githubusercontent.com/signalnerve/lilredirector/master/.github/logo.png" />
         <h1 class="text-2xl font-bold">Lil Redirector</h1>
       </div>
-      <span><code>v0.5.1</code></span>
+      <span><code>v0.9.9</code></span>
     </ul>
 
     <div class="py-6">
@@ -63,209 +37,43 @@ export default ({
                 Redirects (${redirects.length})
               </h2>
             </div>
-            <div class="mt-4 flex-shrink-0 flex md:mt-0 md:ml-4">
-              <span class="shadow-sm rounded-md">
-                <button id="add_redirect_button" type="button" class="inline-flex items-center px-4 py-2 border border-transparent leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:shadow-outline-indigo focus:border-indigo-700 active:bg-indigo-700 transition duration-150 ease-in-out">
-                  + Create Redirect
-                </button>
-              </span>
-              <a class="ml-4 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center" id="export" href="#" class="float-right">
-                <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z"/></svg>
-                <span>Export CSV</span>
-              </a>
-            </div>
           </div>
         </div>
       </header>
 
       <main>
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-          <div class="rounded-md bg-red-100 my-4 p-4" id="flash">
-            <div class="flex">
-              <div class="flex-shrink-0">
-                <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-                </svg>
-              </div>
-              <div class="ml-3">
-                <h3 class="text-sm leading-5 font-medium text-red-800" id="flash_text"></h3>
-              </div>
-            </div>
-          </div>
-
-          <div class="hidden bg-gray-50 overflow-hidden rounded-lg mb-8" id="add_redirect">
-            <form class="px-4 py-5 sm:p-6 w-1/2" action="${baseUrl}/update" method="post">
-              <div class="sm:col-span-3">
-                <label for="path" class="block font-medium leading-5 text-gray-700">Path</label>
-                <div class="mt-1 relative rounded-md shadow-sm">
-                  <input id="path" name="path" class="form-input block w-full sm:text-sm sm:leading-5" placeholder="/about">
-                </div>
-                <p class="mt-2 text-gray-700" id="path-description">Path must be local (e.g. "/about") and should not have any trailing slashes</p>
-              </div>
-
-              <div class="sm:col-span-3 mt-4">
-                <label for="redirect" class="block font-medium leading-5 text-gray-700">Redirect</label>
-                <div class="mt-1 relative rounded-md shadow-sm">
-                  <input id="redirect" name="redirect" class="form-input block w-full sm:text-sm sm:leading-5" placeholder="/about-us">
-                </div>
-                <p class="mt-2 text-gray-700" id="redirect-description">Redirects can be relative (e.g. "/about-us") or absolute ("https://twitter.com/cloudflaredev")</p>
-              </div>
-
-              <details class="sm:col-span-3 mt-4">
-                <summary class="text-gray-700">Add Multiple Redirects</summary>
-                <div class="mt-4">
-                  <label for="bulk" class="block font-medium leading-5 text-gray-700">Bulk Redirects</label>
-                  <div class="mt-1 relative rounded-md shadow-sm">
-                    <textarea id="bulk" name="bulk" rows="3" class="form-textarea block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5"></textarea>
-                  </div>
-                  <p class="mt-2 text-gray-700" id="bulk-description">Redirects should be in CSV format, e.g. "path,redirect_url"</p>
-                </div>
-              </details>
-
-              <div class="mt-4">
-                <button class="mr-4 inline-flex items-center px-4 py-2 border border-transparent leading-5 font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150" type="submit">Save</button>
-                <span class="inline-flex rounded-md shadow-sm">
-                  <button id="close_form" type="button" class="inline-flex items-center px-4 py-2 border border-gray-300 leading-5 font-medium rounded-md text-gray-700 bg-white hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:text-gray-800 active:bg-gray-50 transition ease-in-out duration-150">
-                    Cancel
-                  </button>
-                </span>
-              </div>
-            </form>
-          </div>
-
           <section>
-            ${
-              redirects.length
-                ? `
+            ${redirects.length
+    ? `
             <table class="table-auto">
               <thead>
                 <tr>
                   <th class="px-4 py-2">Path</th>
                   <th class="px-4 py-2">Redirect</th>
-                  <th class="px-4 py-2">Visits*</th>
-                  <th class="px-4 py-2">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 ${redirects
-                  .filter((redirect: Redirect) => !!redirect.path)
-                  .map(
-                    (redirect: Redirect) => `
+      .filter((redirect: Redirect) => !!redirect.path)
+      .map(
+        (redirect: Redirect) => `
                   <tr>
                     <td class="border px-4 py-2">${redirect.path}</td>
                     <td class="border px-4 py-2">${redirect.redirect}</td>
-                    <td class="border px-4 py-2">${redirect.visits}</td>
-                    <td class="border px-4 py-2">
-                      <button class="hover:underline text-gray-800 font-semibold" data-target="${redirect.path}" id="edit">Edit</button>
-                      <button class="hover:underline text-red-800 font-semibold ml-4" data-target="${redirect.path}" id="delete">Delete</button>
-                    </td>
                   </tr>
                 `,
-                  )
-                  .join('\n')}
+      )
+      .join('\n')}
               </tbody>
             </table>
-            <p class="mt-4 text-gray-800">* Visits are an estimate. Distributed systems!</p>
             `
-                : `<p>No redirects created yet!</p>`
-            }
+    : `<p>No redirects created yet!</p>`
+  }
           </section>
         </div>
       </main>
     </div>
-
-    <script id="redirects_data" type="text/json">${JSON.stringify(
-      redirects,
-    )}</script>
-
-    <script>
-      const url = new URL(document.location)
-      const flash = document.querySelector("#flash")
-      const pathInput = document.querySelector("input#path")
-      const redirectInput = document.querySelector("input#redirect")
-      const bulkInput = document.querySelector('textarea#bulk')
-
-      const redirects = JSON.parse(document.querySelector("script#redirects_data").innerText)
-
-      flash.hidden = true
-      const parseErrors = () => {
-        const errorMsg = url.searchParams.get("error")
-        if (errorMsg && errorMsg.length) {
-          document.querySelector("#flash_text").innerText = errorMsg
-          flash.hidden = false
-        }
-      }
-      parseErrors()
-
-      const confirmDeletion = async redirectId => {
-        let url = new URL(window.location)
-        url.pathname = "${baseUrl}/delete"
-        url.searchParams.set("path", redirectId)
-        await window.fetch(url, {
-          method: "DELETE"
-        })
-        window.location.reload()
-      }
-
-      const deleteRedirect = evt => {
-        const button = evt.target
-        const redirectId = button.dataset.target
-        const redirect = redirects.find(({ path }) => path === redirectId)
-        if (window.confirm("are you sure you want to delete the redirect for " + redirect.path + "?")) {
-          confirmDeletion(redirectId)
-        }
-      }
-
-      const editRedirect = evt => {
-        const button = evt.target
-        const redirectId = button.dataset.target
-        const redirect = redirects.find(({ path }) => path === redirectId)
-
-        pathInput.value = redirect.path
-        redirectInput.value = redirect.redirect
-        document.querySelector("#add_redirect").classList.remove("hidden")
-      }
-
-      document.querySelectorAll('button#edit').forEach(button => button.addEventListener('click', editRedirect))
-      document.querySelectorAll('button#delete').forEach(button => button.addEventListener('click', deleteRedirect))
-
-      const validateForm = event => {
-        let valid = true
-
-        if (pathInput.value.length || redirectInput.value.length) {
-          if (bulkInput.value.length) {
-            alert("Can't fill out bulk field and individual redirect")
-            valid = false
-          }
-
-          if (!pathInput.value.length) {
-            valid = false
-            pathInput.classList.add("error")
-          }
-
-          if (!redirectInput.value.length) {
-            valid = false
-            redirectInput.classList.add("error")
-          }
-        }
-
-        if (!pathInput.value.length && !redirectInput.value.length && !bulkInput.value.length) {
-          document.querySelector("#flash_text").innerText = "No redirects provided"
-          flash.hidden = false
-          valid = false
-        }
-
-        if (!valid) {
-          event.preventDefault()
-        }
-      }
-
-      document.querySelector("form").addEventListener('submit', validateForm)
-
-      const toggleForm = () => document.querySelector("#add_redirect").classList.toggle("hidden")
-      document.querySelector("#add_redirect_button").addEventListener('click', toggleForm)
-      document.querySelector("#close_form").addEventListener('click', toggleForm)
-    </script>
   </body>
 </html>
 `

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-export type CSVData = [string, string][]
 export interface Redirect {
   path: string
   redirect: string
-  visits: number
+  visits?: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 export interface Redirect {
   path: string
   redirect: string
-  visits?: number
 }


### PR DESCRIPTION
This PR implements the work described in #11 by implementing file-based redirects for lilredirector. 

This is a _huge_ diff that basically removes all write-behavior in lilredirector -- instead, you'll pass in an array of objects with `path` and `redirect` keys which will match the existing KV-based behavior, just via files:

```js
import redirector from 'lilredirector'

const redirects = [{ path: "/test", redirect: "/" }]

async function handleEvent(event) {
    const { response } = await redirector(event, redirects)
    if (response) return response
}
```

In addition, `lilredirector` now uses https://github.com/berstend/tiny-request-router under-the-hood, so you can use parameters in your redirects:

```js
const redirects = [
  {
    path: "/twitter/:username",
    redirect: "https://twitter.com/:username"
  }
]
```

Closes #10, closes #11